### PR TITLE
Show usage instructions when invoked without args

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-build = "build.rs"
 description = "The CLI app for remembering those little things that slip your mind"
 repository = "https://github.com/codesections/mnemonic"
 homepage = "https://github.com/codesections/mnemonic"
@@ -20,6 +19,3 @@ colored = "1.7.0"
 open = "1.2.2"
 man = "0.3.0"
 
-[build-dependencies]
-clap = "2.23"
-man = "0.3.0"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,4 @@
-use clap::{crate_authors, crate_version, App, Arg, SubCommand};
+use clap::{crate_authors, crate_version, App, AppSettings, Arg, SubCommand};
 pub fn build_cli() -> App<'static, 'static> {
     let CliText {
         app,
@@ -11,6 +11,7 @@ pub fn build_cli() -> App<'static, 'static> {
         ..
     } = CliText::new();
     App::new(app.name)
+        .setting(AppSettings::SubcommandsNegateReqs)
         .version(crate_version!())
         .author(crate_authors!())
         .about(app.description)
@@ -93,7 +94,11 @@ pub fn build_cli() -> App<'static, 'static> {
                         .required(true),
                 ),
         )
-        .arg(Arg::with_name("MNEMONIC").help("the mnemonic to display"))
+        .arg(
+            Arg::with_name("MNEMONIC")
+                .help("the mnemonic to display")
+                .required(true),
+        )
         .arg(
             Arg::with_name("plaintext")
                 .help("Print the mnemonic with no syntax highlighting at all.")


### PR DESCRIPTION
This PR revises the the CLI to provide usage instructions when the user invokes `mn` without any arguments or sub-commands.