### PR TITLE
remove man page

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ And thus, **Mnemonic** was born.  Invoke it with the `mn` command to quickly pri
 
 Currently, you have two installation options, both of which require Rust: 
 * Install with `cargo install mn` (installs only the executable itself)
-* Clone the repository, `cd` into it, and run `make install` (installs the executable, the man page and Zsh completions)
+* Clone the repository, `cd` into it, and run `make install` (installs the executable and Zsh completions (man page and completions for additional shells coming soon))
 
 In the future, additional installation instructions will be supported (including through conventional package managers).
 

--- a/makefile
+++ b/makefile
@@ -4,7 +4,7 @@ install :
 	cargo run --bin generate-docs
 	sudo install -m 0755 -v ./target/release/mn /usr/local/bin/mn
 	# man page
-	sudo cp ./docs/mn.1 /usr/local/share/man/man1/mn.1
+	# sudo cp ./docs/mn.1 /usr/local/share/man/man1/mn.1
 	# Zsh completions
 	sudo install -d /usr/share/zsh/site-functions
 	sudo cp ./completions/_mn /usr/share/zsh/site-functions/_mn


### PR DESCRIPTION
The PR temporarily removes the man page because it is out-of-date.  It will be added back in a future PR soon.