### PR TITLE
Functionalize components

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -543,7 +543,7 @@ dependencies = [
 
 [[package]]
 name = "mn"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "colored 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/add.rs
+++ b/src/add.rs
@@ -20,12 +20,6 @@ pub fn add(
             edit(add_args, &data_dir, fs_state)
         }
     } else {
-        Err(CliErr {
-            code: 1,
-            msg: format!(
-                "{} already exists.  Did you mean to edit it instead?",
-                file_name.yellow().bold()
-            ),
-        })
+        Err(CliErr::MnemonicAlreadyExists(file_name.to_string()))
     }
 }

--- a/src/add.rs
+++ b/src/add.rs
@@ -1,0 +1,31 @@
+use crate::edit;
+use crate::err::CliErr;
+use crate::FsState;
+use clap::ArgMatches;
+use colored::*;
+use std::fs;
+
+pub fn add(
+    add_args: &ArgMatches,
+    data_dir: &str,
+    fs_state: FsState,
+) -> Result<Option<String>, CliErr> {
+    let file_name = add_args.value_of("MNEMONIC").expect("Required by clap");
+    let full_path = format!("{}/{}.md", data_dir, file_name);
+    if !fs_state.file_exists {
+        fs::File::create(&full_path).expect("Can create a file in the project dir");
+        if add_args.is_present("blank") {
+            Ok(Some(format!("{} created.", file_name.blue())))
+        } else {
+            edit(add_args, &data_dir, fs_state)
+        }
+    } else {
+        Err(CliErr {
+            code: 1,
+            msg: format!(
+                "{} already exists.  Did you mean to edit it instead?",
+                file_name.yellow().bold()
+            ),
+        })
+    }
+}

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -1,0 +1,54 @@
+use crate::err::CliErr;
+use crate::input_state::FsState;
+use clap::ArgMatches;
+use colored::*;
+use std::{fs, io::Write, process};
+
+pub fn edit(
+    edit_args: &ArgMatches,
+    data_dir: &str,
+    fs_state: FsState,
+) -> Result<Option<String>, CliErr> {
+    let file_name = edit_args.value_of("MNEMONIC").expect("Required by clap");
+    let full_path = format!("{}/{}.md", data_dir, file_name);
+
+    let editor = fs_state.editor;
+    if fs_state.file_exists {
+        if let Some(text_to_append) = edit_args.value_of("push") {
+            Ok(append_to_mnemonic(&full_path, &file_name, text_to_append))
+        } else if let Some(editor) = editor {
+            process::Command::new(editor)
+                .arg(&full_path)
+                .status()
+                .expect("should be able to open file with editor");
+            Ok(None)
+        } else {
+            open::that(&full_path).is_ok();
+            Ok(None)
+        }
+    } else {
+        Err(CliErr {
+            code: 1,
+            msg: format!(
+                "{} not found.  Would you like to add it to Mnemonic?",
+                file_name.yellow().bold()
+            ),
+        })
+    }
+}
+
+fn append_to_mnemonic(file_path: &str, file_name: &str, text_to_append: &str) -> Option<String> {
+    let mut mnemonic_file = fs::OpenOptions::new()
+        .append(true)
+        .open(file_path)
+        .expect("guaranteed by caller");
+
+    mnemonic_file
+        .write_all(format!("\n{}", text_to_append).as_bytes())
+        .expect("Should be able to write to mnemonic file");
+    Some(format!(
+        "'{}' added to {}",
+        text_to_append,
+        file_name.blue()
+    ))
+}

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -27,13 +27,7 @@ pub fn edit(
             Ok(None)
         }
     } else {
-        Err(CliErr {
-            code: 1,
-            msg: format!(
-                "{} not found.  Would you like to add it to Mnemonic?",
-                file_name.yellow().bold()
-            ),
-        })
+        Err(CliErr::MnemonicNotFound(file_name.to_string()))
     }
 }
 

--- a/src/err.rs
+++ b/src/err.rs
@@ -1,5 +1,30 @@
+use colored::*;
+
 #[derive(Debug)]
-pub struct CliErr {
-    pub msg: String,
-    pub code: i32,
+pub enum CliErr {
+    MnemonicNotFound(String),
+    ErrDeletingMnemonic(String, std::io::Error),
+    MnemonicAlreadyExists(String),
+}
+
+impl CliErr {
+    pub fn handle_err(self) {
+        use CliErr::*;
+        match self {
+            MnemonicNotFound(mnemonic) => eprintln!(
+                "{} not found.  Would you like to add it to Mnemonic?",
+                mnemonic.yellow().bold()
+            ),
+            ErrDeletingMnemonic(mnemonic, err) => eprintln!(
+                "There was an error deleting {}:\n{}",
+                mnemonic.yellow().bold(),
+                err
+            ),
+            MnemonicAlreadyExists(mnemonic) => eprintln!(
+                "{} already exists.  Did you mean to edit it instead?",
+                mnemonic.yellow().bold()
+            ),
+        }
+        std::process::exit(1)
+    }
 }

--- a/src/err.rs
+++ b/src/err.rs
@@ -1,0 +1,5 @@
+#[derive(Debug)]
+pub struct CliErr {
+    pub msg: String,
+    pub code: i32,
+}

--- a/src/input_state.rs
+++ b/src/input_state.rs
@@ -1,0 +1,46 @@
+use clap::ArgMatches;
+use std::{env, ffi, fs, path};
+
+pub struct FsState {
+    pub editor: Option<ffi::OsString>,
+    pub file_exists: bool,
+    pub dir_contents: Option<fs::ReadDir>,
+}
+
+impl FsState {
+    pub fn new() -> Self {
+        Self {
+            editor: None,
+            file_exists: false,
+            dir_contents: None,
+        }
+    }
+    pub fn set_editor(self) -> Self {
+        let editor = if let Some(editor) = env::var_os("VISUAL") {
+            Some(editor)
+        } else {
+            env::var_os("EDITOR")
+        };
+        Self { editor, ..self }
+    }
+
+    pub fn set_file_exists(self, args_from_clap: &ArgMatches, data_dir: &str) -> Self {
+        let file_name = args_from_clap
+            .value_of("MNEMONIC")
+            .expect("Required by clap");
+        let full_path = format!("{}/{}.md", data_dir, file_name);
+        Self {
+            file_exists: path::Path::new(&full_path).exists(),
+            ..self
+        }
+    }
+
+    pub fn set_dir_contents(self, data_dir: &str) -> Self {
+        let dir_contents =
+            fs::read_dir(data_dir).expect("Should be able to read the local data directory");
+        Self {
+            dir_contents: Some(dir_contents),
+            ..self
+        }
+    }
+}

--- a/src/list.rs
+++ b/src/list.rs
@@ -1,0 +1,28 @@
+use crate::err::CliErr;
+use crate::input_state::FsState;
+use colored::*;
+
+pub fn list(fs_state: FsState) -> Result<Option<String>, CliErr> {
+    let mut output_msg = String::new();
+    let mut file_list = vec![];
+    for file in fs_state.dir_contents.expect("Set by caller") {
+        file_list.push(format!(
+            "  - {}",
+            file.expect("file should exist")
+                .path()
+                .file_stem()
+                .expect("file should have valid stem")
+                .to_str()
+                .expect("file should be able to be converted to a string")
+                .blue()
+                .bold()
+        ));
+    }
+
+    output_msg.push_str(format!("Your {} available mnemonics are:\n", file_list.len()).as_str());
+    file_list.sort();
+    for line in file_list {
+        output_msg.push_str(format!("{}\n", line).as_str());
+    }
+    Ok(Some(output_msg))
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -229,3 +229,6 @@ fn show(show_args: &ArgMatches, data_dir: &str) -> Result<Option<String>, (i32, 
         )),
     }
 }
+
+// TODO: Create Err enum
+// TODO: Create FsState struct and pass it to all fn

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,20 @@
+mod add;
 mod cli;
-use clap::ArgMatches;
-use colored::*;
+mod edit;
+mod err;
+mod input_state;
+mod list;
+mod rm;
+mod show;
+
+use add::add;
 use directories::ProjectDirs;
-use open;
-use prettyprint::*;
-use std::io::Write;
-use std::{env, fs, io, path, process};
+use edit::edit;
+use input_state::FsState;
+use list::list;
+use rm::rm;
+use show::show;
+use std::{fs, process};
 
 fn main() {
     let cli_args = cli::build_cli().get_matches();
@@ -21,214 +30,45 @@ fn main() {
         .expect("should be able to create the data directory if it does not already exist");
 
     let result = match cli_args.subcommand() {
-        // TODO: let user rm multiple files in one command
-        ("rm", Some(rm_args)) => rm(rm_args, &data_dir),
-        // TODO: let user specify syntax for mnemonic
-        ("add", Some(add_args)) => add(add_args, &data_dir),
-        ("list", Some(_list_args)) => list(&data_dir),
+        ("rm", Some(rm_args)) => {
+            let fs_state = FsState::new().set_file_exists(rm_args, &data_dir);
+            rm(rm_args, &data_dir, fs_state)
+        }
+        ("add", Some(add_args)) => {
+            let fs_state = FsState::new()
+                .set_editor()
+                .set_file_exists(add_args, &data_dir);
+            add(add_args, &data_dir, fs_state)
+        }
+        ("list", Some(_list_args)) => {
+            let fs_state = FsState::new().set_dir_contents(&data_dir);
+            list(fs_state)
+        }
         // TODO: let user edit syntax for mnemonic
-        ("edit", Some(edit_args)) => edit(edit_args, &data_dir),
-        // TODO let user specify plain text or other syntax
-        ("show", Some(show_args)) => show(&show_args, &data_dir),
-        _ => show(&cli_args, &data_dir),
+        ("edit", Some(edit_args)) => {
+            let fs_state = FsState::new()
+                .set_editor()
+                .set_file_exists(edit_args, &data_dir);
+            edit(edit_args, &data_dir, fs_state)
+        }
+        ("show", Some(show_args)) => {
+            let fs_state = FsState::new().set_file_exists(show_args, &data_dir);
+            show(&show_args, &data_dir, fs_state)
+        }
+        _ => {
+            let fs_state = FsState::new().set_file_exists(&cli_args, &data_dir);
+            show(&cli_args, &data_dir, fs_state)
+        }
     };
 
     match result {
         Ok(Some(msg)) => println!("{}", msg),
         Ok(None) => (),
         Err(err) => {
-            eprintln!("{}", err.1);
-            process::exit(err.0)
+            eprintln!("{}", err.msg);
+            process::exit(err.code)
         }
-    }
-}
-
-fn edit(edit_args: &ArgMatches, data_dir: &str) -> Result<Option<String>, (i32, String)> {
-    let file_name = edit_args.value_of("MNEMONIC").expect("Required by clap");
-    let full_path = format!("{}/{}.md", data_dir, file_name);
-    let editor = if let Some(editor) = env::var_os("VISUAL") {
-        Some(editor)
-    } else {
-        env::var_os("EDITOR")
-    };
-    if path::Path::new(&full_path).exists() {
-        if let Some(text_to_append) = edit_args.value_of("push") {
-            Ok(append_to_mnemonic(&full_path, &file_name, text_to_append))
-        } else if let Some(editor) = editor {
-            process::Command::new(editor)
-                .arg(&full_path)
-                .status()
-                .expect("should be able to open file with editor");
-            Ok(None)
-        } else {
-            open::that(&full_path).is_ok();
-            Ok(None)
-        }
-    } else {
-        Err((
-            1,
-            format!(
-                "{} not found.  Would you like to add it to Mnemonic?",
-                file_name.yellow().bold()
-            ),
-        ))
-    }
-}
-fn append_to_mnemonic(file_path: &str, file_name: &str, text_to_append: &str) -> Option<String> {
-    let mut mnemonic_file = fs::OpenOptions::new()
-        .append(true)
-        .open(file_path)
-        .expect("guaranteed by caller");
-
-    mnemonic_file
-        .write_all(format!("\n{}", text_to_append).as_bytes())
-        .expect("Should be able to write to mnemonic file");
-    Some(format!(
-        "'{}' added to {}",
-        text_to_append,
-        file_name.blue()
-    ))
-}
-
-fn add(add_args: &ArgMatches, data_dir: &str) -> Result<Option<String>, (i32, String)> {
-    let file_name = add_args.value_of("MNEMONIC").expect("Required by clap");
-    let full_path = format!("{}/{}.md", data_dir, file_name);
-    if !path::Path::new(&full_path).exists() {
-        fs::File::create(&full_path).unwrap();
-        if add_args.is_present("blank") {
-            Ok(Some(format!("{} created.", file_name.blue())))
-        } else {
-            edit(add_args, &data_dir)
-        }
-    } else {
-        Err((
-            1,
-            format!(
-                "{} already exists.  Did you mean to edit it instead?",
-                file_name.yellow().bold()
-            ),
-        ))
-    }
-}
-
-fn rm(rm_args: &ArgMatches, data_dir: &str) -> Result<Option<String>, (i32, String)> {
-    let file_name_arguments = rm_args.values_of("MNEMONIC").expect("required by clap");
-    let mut output_msg = String::new();
-    for file_name in file_name_arguments {
-        let full_path = format!("{}/{}.md", data_dir, file_name);
-        if !path::Path::new(&full_path).exists() {
-            return Err((
-                1,
-                format!("No mnemonic named {} exists", file_name.yellow().bold()),
-            ));
-        }
-        if rm_args.is_present("force") {
-            let file_deleted_msg = delete_file(full_path, file_name)?;
-            output_msg.push_str(format!("{}\n", file_deleted_msg.unwrap()).as_str());
-        } else {
-            println!(
-                "Are you sure you want to delete {}? [y/n]",
-                file_name.yellow().bold()
-            );
-            let mut answer = String::new();
-            io::stdin()
-                .read_line(&mut answer)
-                .expect("Should be able to read input from stdin");
-            loop {
-                match &answer[..] {
-                    "y\n" | "yes\n" => {
-                        let file_deleted_msg = delete_file(full_path, file_name)?;
-                        output_msg.push_str(format!("{}\n", file_deleted_msg.unwrap()).as_str());
-                        break;
-                    }
-                    "n\n" | "no\n" => break,
-                    _ => {
-                        println!("Please type 'yes' ('y') or 'no' ('n')");
-                        answer = String::new();
-                        io::stdin()
-                            .read_line(&mut answer)
-                            .expect("Should be able to read input from stdin");
-                    }
-                }
-            }
-        }
-    }
-    Ok(Some(output_msg))
-}
-
-fn delete_file(full_path: String, file_name: &str) -> Result<Option<String>, (i32, String)> {
-    match fs::remove_file(full_path) {
-        Err(e) => Err((
-            1,
-            format!(
-                "There was an error deleting {}:\n{}",
-                file_name.yellow().bold(),
-                e
-            ),
-        )),
-        _ => Ok(Some(format!("{} has been deleted.", file_name.blue()))),
-    }
-}
-
-fn list(data_dir: &str) -> Result<Option<String>, (i32, String)> {
-    let mut output_msg = String::new();
-    let mut file_list = vec![];
-    for file in fs::read_dir(data_dir).expect("Should be able to read the local data directory") {
-        file_list.push(format!(
-            "  - {}",
-            file.expect("file should exist")
-                .path()
-                .file_stem()
-                .expect("file should have valid stem")
-                .to_str()
-                .expect("file should be able to be converted to a string")
-                .blue()
-                .bold()
-        ));
-    }
-
-    output_msg.push_str(format!("Your {} available mnemonics are:\n", file_list.len()).as_str());
-    file_list.sort();
-    for line in file_list {
-        output_msg.push_str(format!("{}\n", line).as_str());
-    }
-    Ok(Some(output_msg))
-}
-
-fn show(show_args: &ArgMatches, data_dir: &str) -> Result<Option<String>, (i32, String)> {
-    use std::io::prelude::*;
-    let usr_supplied_file_name = show_args.value_of("MNEMONIC").expect("Required by clap");
-    let full_path = format!("{}/{}.md", &data_dir, usr_supplied_file_name);
-    if show_args.is_present("plaintext") {
-        let mut file = fs::File::open(&full_path).expect("should be able to open mnemonic");
-        let mut plaintext = String::new();
-        file.read_to_string(&mut plaintext)
-            .expect("should be able to read open file to string");
-
-        return Ok(Some(plaintext));
-    }
-    let theme = show_args.value_of("theme").unwrap_or("TwoDark");
-    let syntax_language = show_args.value_of("syntax").unwrap_or("md");
-    let printer = PrettyPrinter::default()
-        .header(false)
-        .grid(false)
-        .language(syntax_language)
-        .theme(theme)
-        .line_numbers(false)
-        .build()
-        .expect("should be able to build a formater");
-
-    match printer.file(full_path) {
-        Ok(_) => Ok(None),
-        Err(_) => Err((
-            1,
-            format!(
-                "{} not found.  Would you like to add it to Mnemonic?",
-                usr_supplied_file_name.yellow().bold()
-            ),
-        )),
     }
 }
 
 // TODO: Create Err enum
-// TODO: Create FsState struct and pass it to all fn

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,13 +14,12 @@ use input_state::FsState;
 use list::list;
 use rm::rm;
 use show::show;
-use std::{fs, process};
+use std::fs;
 
 fn main() {
     let cli_args = cli::build_cli().get_matches();
-    let data_dir =
-        ProjectDirs::from("", "", "mn").expect("Should be able to determine project directory");
-    let data_dir = data_dir
+    let data_dir = ProjectDirs::from("", "", "mn")
+        .expect("Should be able to determine project directory")
         .data_local_dir()
         .to_str()
         .expect("Should be able to find local data directory inside project directory")
@@ -62,13 +61,8 @@ fn main() {
     };
 
     match result {
-        Ok(Some(msg)) => println!("{}", msg),
         Ok(None) => (),
-        Err(err) => {
-            eprintln!("{}", err.msg);
-            process::exit(err.code)
-        }
+        Ok(Some(msg)) => println!("{}", msg),
+        Err(cli_err) => cli_err.handle_err(),
     }
 }
-
-// TODO: Create Err enum

--- a/src/rm.rs
+++ b/src/rm.rs
@@ -1,0 +1,70 @@
+use crate::err::CliErr;
+use crate::input_state::FsState;
+use clap::ArgMatches;
+use colored::*;
+use std::{fs, io};
+
+pub fn rm(
+    rm_args: &ArgMatches,
+    data_dir: &str,
+    fs_state: FsState,
+) -> Result<Option<String>, CliErr> {
+    let file_name_arguments = rm_args.values_of("MNEMONIC").expect("required by clap");
+    let mut output_msg = String::new();
+    for file_name in file_name_arguments {
+        let full_path = format!("{}/{}.md", data_dir, file_name);
+        if !fs_state.file_exists {
+            return Err(CliErr {
+                code: 1,
+                msg: format!("No mnemonic named {} exists", file_name.yellow().bold()),
+            });
+        }
+        if rm_args.is_present("force") {
+            let file_deleted_msg = delete_file(full_path, file_name)?;
+            output_msg.push_str(format!("{}\n", file_deleted_msg.unwrap()).as_str());
+        } else {
+            println!(
+                "Are you sure you want to delete {}? [y/n]",
+                file_name.yellow().bold()
+            );
+            let mut answer = String::new();
+            // NOTE: state
+            io::stdin()
+                .read_line(&mut answer)
+                .expect("Should be able to read input from stdin");
+            loop {
+                match &answer[..] {
+                    "y\n" | "yes\n" => {
+                        let file_deleted_msg = delete_file(full_path, file_name)?;
+                        output_msg.push_str(format!("{}\n", file_deleted_msg.unwrap()).as_str());
+                        break;
+                    }
+                    "n\n" | "no\n" => break,
+                    _ => {
+                        println!("Please type 'yes' ('y') or 'no' ('n')");
+                        answer = String::new();
+                        io::stdin()
+                            .read_line(&mut answer)
+                            .expect("Should be able to read input from stdin");
+                    }
+                }
+            }
+        }
+    }
+    Ok(Some(output_msg))
+}
+
+fn delete_file(full_path: String, file_name: &str) -> Result<Option<String>, CliErr> {
+    // NOTE: state
+    match fs::remove_file(full_path) {
+        Err(e) => Err(CliErr {
+            code: 1,
+            msg: format!(
+                "There was an error deleting {}:\n{}",
+                file_name.yellow().bold(),
+                e
+            ),
+        }),
+        _ => Ok(Some(format!("{} has been deleted.", file_name.blue()))),
+    }
+}

--- a/src/rm.rs
+++ b/src/rm.rs
@@ -14,10 +14,7 @@ pub fn rm(
     for file_name in file_name_arguments {
         let full_path = format!("{}/{}.md", data_dir, file_name);
         if !fs_state.file_exists {
-            return Err(CliErr {
-                code: 1,
-                msg: format!("No mnemonic named {} exists", file_name.yellow().bold()),
-            });
+            return Err(CliErr::MnemonicNotFound(file_name.to_string()));
         }
         if rm_args.is_present("force") {
             let file_deleted_msg = delete_file(full_path, file_name)?;
@@ -57,14 +54,7 @@ pub fn rm(
 fn delete_file(full_path: String, file_name: &str) -> Result<Option<String>, CliErr> {
     // NOTE: state
     match fs::remove_file(full_path) {
-        Err(e) => Err(CliErr {
-            code: 1,
-            msg: format!(
-                "There was an error deleting {}:\n{}",
-                file_name.yellow().bold(),
-                e
-            ),
-        }),
+        Err(e) => Err(CliErr::ErrDeletingMnemonic(file_name.to_string(), e)),
         _ => Ok(Some(format!("{} has been deleted.", file_name.blue()))),
     }
 }

--- a/src/show.rs
+++ b/src/show.rs
@@ -1,0 +1,45 @@
+use crate::err::CliErr;
+use crate::input_state::FsState;
+use clap::ArgMatches;
+use colored::*;
+use prettyprint::*;
+use std::{fs, io::Read};
+
+pub fn show(
+    show_args: &ArgMatches,
+    data_dir: &str,
+    fs_state: FsState,
+) -> Result<Option<String>, CliErr> {
+    let usr_supplied_file_name = show_args.value_of("MNEMONIC").expect("Required by clap");
+    let full_path = format!("{}/{}.md", &data_dir, usr_supplied_file_name);
+    if fs_state.file_exists {
+        if show_args.is_present("plaintext") {
+            let mut file = fs::File::open(&full_path).expect("should be able to open mnemonic");
+            let mut plaintext = String::new();
+            file.read_to_string(&mut plaintext)
+                .expect("should be able to read open file to string");
+            return Ok(Some(plaintext));
+        }
+        let theme = show_args.value_of("theme").unwrap_or("TwoDark");
+        let syntax_language = show_args.value_of("syntax").unwrap_or("md");
+        PrettyPrinter::default()
+            .header(false)
+            .grid(false)
+            .language(syntax_language)
+            .theme(theme)
+            .line_numbers(false)
+            .build()
+            .expect("should be able to build a formater")
+            .file(full_path)
+            .expect("should be able to print existing file");
+        Ok(None)
+    } else {
+        Err(CliErr {
+            code: 1,
+            msg: format!(
+                "{} not found.  Would you like to add it to Mnemonic?",
+                usr_supplied_file_name.yellow().bold()
+            ),
+        })
+    }
+}

--- a/src/show.rs
+++ b/src/show.rs
@@ -1,7 +1,6 @@
 use crate::err::CliErr;
 use crate::input_state::FsState;
 use clap::ArgMatches;
-use colored::*;
 use prettyprint::*;
 use std::{fs, io::Read};
 
@@ -34,12 +33,6 @@ pub fn show(
             .expect("should be able to print existing file");
         Ok(None)
     } else {
-        Err(CliErr {
-            code: 1,
-            msg: format!(
-                "{} not found.  Would you like to add it to Mnemonic?",
-                usr_supplied_file_name.yellow().bold()
-            ),
-        })
+        Err(CliErr::MnemonicNotFound(usr_supplied_file_name.to_string()))
     }
 }


### PR DESCRIPTION
This PR refactors each component to take additional parameters based on the file system state and then to return a `Result`.  (In contrast the old design allowed each component to read file-system state directly, to print output directly, and to end the process itself).

The updated design should facilitate testing.