### PR TITLE
Hotfix for panic when config dir does not exist

### DIFF
--- a/src/add.rs
+++ b/src/add.rs
@@ -9,6 +9,7 @@ pub fn add(state: State) -> Result<Option<String>, CliErr> {
     let file_name = &state.mnemonics()[0].clone();
     let full_path = format!("{}/{}.md", &state.directory(), file_name);
     if !utils::new_mn_exists(&file_name, &state) {
+        fs::create_dir_all(&state.directory()).expect("Should be able to create a directory");
         fs::File::create(&full_path).expect("Can create a file in the project dir");
         let state = state.with_new_mnemonic_file(file_name.to_string());
         if *state.add().blank() {

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -114,10 +114,18 @@ impl State {
                     .expect("invalid doc");
                 state_with_comments["edit"]["editor"] = value(default_editor.clone());
                 state_with_comments["add"]["editor"] = value(default_editor);
-                state_with_comments["directory"] = value(directory);
-                let mut file = fs::File::create(&config_file).unwrap();
-                file.write_all(state_with_comments.to_string().as_bytes())
-                    .unwrap();
+                state_with_comments["directory"] = value(directory.clone());
+                fs::create_dir_all(&config_dir).expect("Should be able to create a directory");
+                let mut file = fs::File::create(&config_file).unwrap_or_else(|e|{
+                    // TODO: make this a Result? Print in color?
+                    eprintln!("Error writing your config file, {}.\n{}\nPlease ensure that you have write permissions in {}", config_file, e, config_dir);
+                    std::process::exit(1);
+                });
+                file.write_all(state_with_comments.to_string().as_bytes()).unwrap_or_else(|e|{
+                    // TODO: make this a Result? Print in color?
+                    eprintln!("Error writing your config file, {}.\n{}\nPlease ensure that you have write permissions in {}", config_file, e, config_dir);
+                    std::process::exit(1);
+                });
 
                 state
             }


### PR DESCRIPTION
This PR fixes the issue where the config file was written to a directory that may not exist, leading to a panic.  This commit creates the directory if it does not exist and improves error handling if something goes wrong, avoiding the panic.