### PR TITLE
Significantly expand error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -398,6 +398,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "failure"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "backtrace 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "failure_derive"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "flate2"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -508,6 +528,14 @@ dependencies = [
  "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "itertools"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -663,6 +691,8 @@ dependencies = [
  "colored 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "derive_builder 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "directories 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "man 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "open 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "prettyprint 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1092,6 +1122,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "syntect"
 version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1371,6 +1412,8 @@ dependencies = [
 "checksum encoding-index-tradchinese 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)" = "fd0e20d5688ce3cab59eb3ef3a2083a5c77bf496cb798dc6fcdb75f323890c18"
 "checksum encoding_index_tests 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a246d82be1c9d791c5dfde9a2bd045fc3cbba3fa2b11ad558f27d01712f00569"
 "checksum error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "07e791d3be96241c77c43846b665ef1384606da2cd2a48730abe606a12906e02"
+"checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
+"checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
 "checksum flate2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2291c165c8e703ee54ef3055ad6188e3d51108e2ded18e9f2476e774fc5ad3d4"
 "checksum float-cmp 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "134a8fa843d80a51a5b77d36d42bc2def9edcb0262c914861d08129fd1926600"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
@@ -1383,6 +1426,7 @@ dependencies = [
 "checksum ident_case 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3c9826188e666f2ed92071d2dadef6edc430b11b158b5b2b3f4babbcc891eaaa"
 "checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
 "checksum ignore 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ad03ca67dc12474ecd91fdb94d758cbd20cb4e7a78ebe831df26a9b7511e1162"
+"checksum itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5b8467d9c1cebe26feb08c640139247fac215782d35371ade9a2136ed6085358"
 "checksum itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
@@ -1453,6 +1497,7 @@ dependencies = [
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
 "checksum syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)" = "f92e629aa1d9c827b2bb8297046c1ccffc57c99b947a680d3ccff1f136a3bee9"
+"checksum synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015"
 "checksum syntect 3.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e02dd9df97a68a2d005ace28ff24c610abfc3ce17afcfdb22a077645dabb599a"
 "checksum tempfile 3.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "7e91405c14320e5c79b3d148e1c86f40749a36e490642202a31689cb1a3452b2"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"

--- a/src/add.rs
+++ b/src/add.rs
@@ -5,15 +5,15 @@ use crate::utils;
 use colored::*;
 use std::fs;
 
-pub fn add(state: State) -> Result<Option<String>, CliErr> {
+pub fn add(state: State) -> Result<String, CliErr> {
     let file_name = &state.mnemonics()[0].clone();
     let full_path = format!("{}/{}.md", &state.directory(), file_name);
     if !utils::new_mn_exists(&file_name, &state) {
         fs::create_dir_all(&state.directory())?;
-        fs::File::create(&full_path).expect("Can create a file in the project dir");
+        fs::File::create(&full_path)?;
         let state = state.with_new_mnemonic_file(file_name.to_string());
         if *state.add().blank() {
-            Ok(Some(format!("{} created.", file_name.blue())))
+            Ok(format!("{} created.", file_name.blue()))
         } else {
             edit(state)
         }
@@ -31,9 +31,9 @@ mod tests {
 
     #[test]
     fn add_mn_that_exitst() {
-        let temp_dir = TempDir::new().unwrap();
+        let temp_dir = TempDir::new().expect("test");
         let temp_dir_path = format!("{}", temp_dir.path().display());
-        temp_dir.child("already_exists.md").touch().unwrap();
+        temp_dir.child("already_exists.md").touch().expect("test");
         let state = State::from_test_state(
             TestStateBuilder::new()
                 .directory(temp_dir_path)
@@ -43,16 +43,16 @@ mod tests {
                         .blank(true)
                         .editor("nvim")
                         .build()
-                        .unwrap(),
+                        .expect("test"),
                 )
                 .filesystem(
                     FileSystemBuilder::new()
                         .mnemonic_files(vec!["mn0".to_string()])
                         .build()
-                        .unwrap(),
+                        .expect("test"),
                 )
                 .build()
-                .unwrap(),
+                .expect("test"),
         );
 
         match add(state) {
@@ -67,7 +67,7 @@ mod tests {
 
     #[test]
     fn add_a_new_mn_with_editor() {
-        let temp_dir = TempDir::new().unwrap();
+        let temp_dir = TempDir::new().expect("test");
         let temp_dir_path = format!("{}", temp_dir.path().display());
         let state = State::from_test_state(
             TestStateBuilder::new()
@@ -78,10 +78,10 @@ mod tests {
                         .blank(true)
                         .editor("nvim")
                         .build()
-                        .unwrap(),
+                        .expect("test"),
                 )
                 .build()
-                .unwrap(),
+                .expect("test"),
         );
 
         match add(state) {
@@ -92,7 +92,7 @@ mod tests {
 
     #[test]
     fn add_a_new_mn_with_xdg_open() {
-        let temp_dir = TempDir::new().unwrap();
+        let temp_dir = TempDir::new().expect("test");
         let temp_dir_path = format!("{}", temp_dir.path().display());
         let state = State::from_test_state(
             TestStateBuilder::new()
@@ -103,10 +103,10 @@ mod tests {
                         .blank(true)
                         .editor("foo")
                         .build()
-                        .unwrap(),
+                        .expect("test"),
                 )
                 .build()
-                .unwrap(),
+                .expect("test"),
         );
 
         match add(state) {
@@ -117,7 +117,7 @@ mod tests {
 
     #[test]
     fn add_a_blank_mn() {
-        let temp_dir = TempDir::new().unwrap();
+        let temp_dir = TempDir::new().expect("test");
         let temp_dir_path = format!("{}", temp_dir.path().display());
         let state = State::from_test_state(
             TestStateBuilder::new()
@@ -128,15 +128,15 @@ mod tests {
                         .blank(true)
                         .editor("nvim")
                         .build()
-                        .unwrap(),
+                        .expect("test"),
                 )
                 .build()
-                .unwrap(),
+                .expect("test"),
         );
 
         match add(state) {
             Err(e) => assert!(false, format!("No errors, such as: {:?}", e)),
-            Ok(msg) => assert_eq!(msg, Some(format!("{} created.", "mn0".blue()))),
+            Ok(msg) => assert_eq!(msg, format!("{} created.", "mn0".blue())),
         }
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -88,9 +88,7 @@ pub fn build_cli() -> App<'static, 'static> {
                         .long(theme.long)
                         .short(theme.short)
                         .takes_value(true)
-                        .possible_values(
-                            &theme.possible_values.clone().expect("Set these ourself"),
-                        ),
+                        .possible_values(&theme.possible_values),
                 )
                 .arg(
                     Arg::with_name("plaintext")
@@ -123,7 +121,7 @@ pub fn build_cli() -> App<'static, 'static> {
                 .long(theme.long)
                 .short(theme.short)
                 .takes_value(true)
-                .possible_values(&theme.possible_values.expect("Set these ourself"))
+                .possible_values(&theme.possible_values)
                 .hidden(true),
         )
         .arg(
@@ -157,7 +155,7 @@ pub struct OptValues {
     pub help: &'static str,
     pub value_name: &'static str,
     pub default_value: &'static str,
-    pub possible_values: Option<Vec<&'static str>>,
+    pub possible_values: Vec<&'static str>,
 }
 pub struct HeaderInfo {
     pub name: &'static str,
@@ -232,7 +230,7 @@ impl CliText {
                 help: "Pushes a new line to the provided mnemonic",
                 value_name: "NEW_TEXT",
                 default_value: "",
-                possible_values: None,
+                possible_values: Vec::new(),
             },
             theme: OptValues {
                 name: "theme",
@@ -241,7 +239,7 @@ impl CliText {
                 help: "Sets a color scheme for the displayed mnemonic",
                 value_name: "COLOR_SCHEME",
                 default_value: "",
-                possible_values: Some(vec![
+                possible_values: vec![
                     "1337",
                     "DarkNeon",
                     "GitHub",
@@ -254,7 +252,7 @@ impl CliText {
                     "Sublime Snazzy",
                     "TwoDark",
                     "zenburn",
-                ]),
+                ],
             },
         }
     }

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -4,13 +4,13 @@ use crate::utils;
 use colored::*;
 use std::{fs, io::Write};
 
-pub fn edit(state: State) -> Result<Option<String>, CliErr> {
+pub fn edit(state: State) -> Result<String, CliErr> {
     let file_name = state.mnemonics()[0].clone();
     let full_path = format!("{}/{}.md", state.directory(), &file_name);
 
     if utils::new_mn_exists(&file_name, &state) {
         if let Some(text_to_append) = &state.edit().push() {
-            Ok(append_to_mnemonic(&full_path, &file_name, &text_to_append))
+            Ok(append_to_mnemonic(&full_path, &file_name, &text_to_append)?)
         } else {
             #[cfg(not(test))]
             match std::process::Command::new(state.add().editor().clone())
@@ -19,26 +19,25 @@ pub fn edit(state: State) -> Result<Option<String>, CliErr> {
             {
                 Ok(_) => (),
                 Err(_) => {
-                    open::that(&full_path).expect("can open with xdg-open");
+                    open::that(&full_path)?;
                 }
             }
-            Ok(None)
+            Ok(String::new())
         }
     } else {
         Err(CliErr::MnemonicNotFound(file_name.to_string()))
     }
 }
 
-fn append_to_mnemonic(file_path: &str, file_name: &str, text_to_append: &str) -> Option<String> {
-    let mut mnemonic_file = fs::OpenOptions::new()
-        .append(true)
-        .open(file_path)
-        .expect("guaranteed by caller");
+fn append_to_mnemonic(
+    file_path: &str,
+    file_name: &str,
+    text_to_append: &str,
+) -> Result<String, CliErr> {
+    let mut mnemonic_file = fs::OpenOptions::new().append(true).open(file_path)?;
+    mnemonic_file.write_all(format!("\n{}", text_to_append).as_bytes())?;
 
-    mnemonic_file
-        .write_all(format!("\n{}", text_to_append).as_bytes())
-        .expect("Should be able to write to mnemonic file");
-    Some(format!(
+    Ok(format!(
         "'{}' added to {}",
         text_to_append,
         file_name.blue()
@@ -54,14 +53,14 @@ mod tests {
 
     #[test]
     fn edit_non_existant_mn() {
-        let temp_dir = TempDir::new().unwrap();
+        let temp_dir = TempDir::new().expect("test");
         let temp_dir_path = format!("{}", temp_dir.path().display());
         let state = State::from_test_state(
             TestStateBuilder::new()
                 .directory(temp_dir_path)
                 .mnemonics(vec!["mn0".to_string()])
                 .build()
-                .unwrap(),
+                .expect("test"),
         );
 
         match edit(state) {
@@ -73,9 +72,9 @@ mod tests {
 
     #[test]
     fn edit_mn_with_editor() {
-        let temp_dir = TempDir::new().unwrap();
+        let temp_dir = TempDir::new().expect("test");
         let temp_dir_path = format!("{}", temp_dir.path().display());
-        temp_dir.child("mn0.md").touch().unwrap();
+        temp_dir.child("mn0.md").touch().expect("test");
         let state = State::from_test_state(
             TestStateBuilder::new()
                 .directory(temp_dir_path)
@@ -84,10 +83,10 @@ mod tests {
                     FileSystemBuilder::new()
                         .mnemonic_files(vec!["mn0".to_string()])
                         .build()
-                        .unwrap(),
+                        .expect("test"),
                 )
                 .build()
-                .unwrap(),
+                .expect("test"),
         );
 
         match edit(state) {
@@ -98,9 +97,9 @@ mod tests {
 
     #[test]
     fn edit_mn_with_xdg_open() {
-        let temp_dir = TempDir::new().unwrap();
+        let temp_dir = TempDir::new().expect("test");
         let temp_dir_path = format!("{}", temp_dir.path().display());
-        temp_dir.child("mn0.md").touch().unwrap();
+        temp_dir.child("mn0.md").touch().expect("test");
         let state = State::from_test_state(
             TestStateBuilder::new()
                 .directory(temp_dir_path)
@@ -109,10 +108,10 @@ mod tests {
                     FileSystemBuilder::new()
                         .mnemonic_files(vec!["mn0".to_string()])
                         .build()
-                        .unwrap(),
+                        .expect("test"),
                 )
                 .build()
-                .unwrap(),
+                .expect("test"),
         );
 
         match edit(state) {
@@ -125,11 +124,11 @@ mod tests {
     fn append_to_a_mn() {
         use std::fs::File;
         use std::io::prelude::*;
-        let temp_dir = TempDir::new().unwrap();
+        let temp_dir = TempDir::new().expect("test");
         let temp_dir_path = format!("{}", temp_dir.path().display());
 
         let temp_file = temp_dir.child("mn0.md");
-        temp_file.touch().unwrap();
+        temp_file.touch().expect("test");
         let temp_file_path = format!("{}", temp_file.path().display());
 
         let state = State::from_test_state(
@@ -140,16 +139,16 @@ mod tests {
                     FileSystemBuilder::new()
                         .mnemonic_files(vec!["mn0".to_string()])
                         .build()
-                        .unwrap(),
+                        .expect("test"),
                 )
                 .edit(
                     EditBuilder::new()
                         .push(Some("text to append".to_string()))
                         .build()
-                        .unwrap(),
+                        .expect("test"),
                 )
                 .build()
-                .unwrap(),
+                .expect("test"),
         );
 
         match edit(state) {
@@ -158,8 +157,8 @@ mod tests {
         }
 
         let mut file_contents = String::new();
-        let mut temp_file = File::open(temp_file_path).unwrap();
-        temp_file.read_to_string(&mut file_contents).unwrap();
+        let mut temp_file = File::open(temp_file_path).expect("test");
+        temp_file.read_to_string(&mut file_contents).expect("test");
         assert_eq!("\ntext to append", file_contents)
     }
 }

--- a/src/err.rs
+++ b/src/err.rs
@@ -1,5 +1,3 @@
-use colored::*;
-
 #[derive(Debug)]
 pub enum CliErr {
     MnemonicNotFound(String),
@@ -7,32 +5,63 @@ pub enum CliErr {
     MnemonicAlreadyExists(String),
     InputOutput(std::io::Error),
     Toml(toml::de::Error),
-    ParseEnv(std::ffi::OsString),
+    TomlEdit(toml_edit::TomlError),
+    ParseUnicode(String),
+    CannotPrettyPrint(String),
+    LocateDirs,
+    #[allow(dead_code)]
+    CannotGenerateManPage(String, std::io::Error),
 }
 
 impl CliErr {
     pub fn handle_err(self) {
+        use colored::*;
         use CliErr::*;
-        match self {
-            MnemonicNotFound(mnemonic) => eprintln!(
+        let (err_msg, err_code) = match self {
+            MnemonicNotFound(mnemonic) => (format!(
                 "You do not have a mnemonic named {}.\nYou can add it with `mn add {}`",
                 mnemonic.yellow().bold(),
                 mnemonic,
-            ),
-            ErrDeletingMnemonic(mnemonic, err) => eprintln!(
+            ), 1),
+            ErrDeletingMnemonic(mnemonic, err) => (format!(
                 "There was an error deleting {}:\n{}",
                 mnemonic.yellow().bold(),
                 err
-            ),
-            MnemonicAlreadyExists(mnemonic) => eprintln!(
+            ), 2),
+            MnemonicAlreadyExists(mnemonic) => (format!(
                 "{} already exists.  Did you mean to edit it instead?",
                 mnemonic.yellow().bold()
-            ),
-            InputOutput(err) => eprintln!("Error accessing file: {}", err),
-            Toml(err) => eprintln!("Could not read your config file.  Please make sure all valid keys are present or reset to default.  {}", err),
-            ParseEnv(err) => eprintln!("Could not read environmental variables.  Please ensure $VISUAL and $EDITOR are set to valid Unicode values: {:?}", err),
-        }
-        std::process::exit(1)
+            ), 3),
+            InputOutput(err) => (format!(
+                "Error accessing file: {}",
+                err
+            ), 4),
+            Toml(err) => (format!(
+                "Could not read your config file due to: {}.\nPlease make sure all valid keys are present or reset to default.",
+                err.to_string().yellow().bold()
+            ), 5),
+            TomlEdit(err) => (format!(
+                "Could not read your config file due to: {}.\nPlease make sure all valid keys are present or reset to default.",
+                err.to_string().yellow().bold()
+            ), 5),
+            ParseUnicode(unreadable_os_string) => (format!(
+                "Could not read {}",
+                unreadable_os_string,
+            ), 6),
+            CannotPrettyPrint(err)=> (format!(
+                "Could not format mnemonic for printing\n{}",
+                err,
+            ), 6),
+            LocateDirs => (
+                "Could not determine the proper directory to store files.  Please select a directory in your configuration file and try again.".to_string(),
+            7),
+            CannotGenerateManPage(path_to_man_page, err) => (format!(
+                "Could not generate the manual page at {}: {}", path_to_man_page, err
+            ), 8),
+
+        };
+        eprintln!("{}", err_msg);
+        std::process::exit(err_code)
     }
 }
 
@@ -47,9 +76,8 @@ impl From<toml::de::Error> for CliErr {
         CliErr::Toml(err)
     }
 }
-
-impl From<std::ffi::OsString> for CliErr {
-    fn from(err: std::ffi::OsString) -> CliErr {
-        CliErr::ParseEnv(err)
+impl From<toml_edit::TomlError> for CliErr {
+    fn from(err: toml_edit::TomlError) -> CliErr {
+        CliErr::TomlEdit(err)
     }
 }

--- a/src/list.rs
+++ b/src/list.rs
@@ -2,7 +2,7 @@ use crate::err::CliErr;
 use crate::state::State;
 use colored::*;
 
-pub fn list(state: State) -> Result<Option<String>, CliErr> {
+pub fn list(state: State) -> Result<String, CliErr> {
     let mut output_msg = String::new();
     let mut file_list = vec![];
     for file in state.filesystem().mnemonic_files() {
@@ -10,7 +10,7 @@ pub fn list(state: State) -> Result<Option<String>, CliErr> {
     }
 
     match file_list.len() {
-        0 => return Ok(Some("You don't have any mnemonics yet.  Use `mn add <MNEMONIC>` to create your first mnemonic.".to_string())),
+        0 => return Ok("You don't have any mnemonics yet.  Use `mn add <MNEMONIC>` to create your first mnemonic.".to_string()),
         1 => output_msg.push_str("Your 1 available mnemonic is:\n"),
         _ => output_msg.push_str(format!("Your {} available mnemonics are:\n", file_list.len()).as_str()),
     }
@@ -19,7 +19,7 @@ pub fn list(state: State) -> Result<Option<String>, CliErr> {
     for line in file_list {
         output_msg.push_str(format!("{}\n", line).as_str());
     }
-    Ok(Some(output_msg))
+    Ok(output_msg)
 }
 
 #[cfg(test)]
@@ -31,20 +31,20 @@ mod tests {
 
     #[test]
     fn list_zero_mns() {
-        let temp_dir = TempDir::new().unwrap();
+        let temp_dir = TempDir::new().expect("test");
         let temp_dir_path = format!("{}", temp_dir.path().display());
 
         let state = State::from_test_state(
             TestStateBuilder::new()
                 .directory(temp_dir_path)
                 .build()
-                .unwrap(),
+                .expect("test"),
         )
-        .and_from_filesystem();
+        .and_from_filesystem()
+        .expect("test");
         match list(state) {
             Err(_) => assert!(false, "No other errors"),
-            Ok(None) => assert!(false),
-            Ok(Some(msg)) => assert_eq!(
+            Ok(msg) => assert_eq!(
                 msg,
                 String::from("You don't have any mnemonics yet.  Use `mn add <MNEMONIC>` to create your first mnemonic.")
             ),
@@ -53,22 +53,22 @@ mod tests {
 
     #[test]
     fn list_one_mn() {
-        let temp_dir = TempDir::new().unwrap();
+        let temp_dir = TempDir::new().expect("test");
         let temp_dir_path = format!("{}", temp_dir.path().display());
 
-        temp_dir.child("mn0.md").touch().unwrap();
+        temp_dir.child("mn0.md").touch().expect("test");
         let state = State::from_test_state(
             TestStateBuilder::new()
                 .directory(temp_dir_path)
                 .build()
-                .unwrap(),
+                .expect("test"),
         )
-        .and_from_filesystem();
+        .and_from_filesystem()
+        .expect("test");
 
         match list(state) {
             Err(_) => assert!(false, "No other errors"),
-            Ok(None) => assert!(false),
-            Ok(Some(msg)) => assert_eq!(
+            Ok(msg) => assert_eq!(
                 msg,
                 format!(
                     "Your 1 available mnemonic is:\n  - {}\n",
@@ -80,24 +80,24 @@ mod tests {
 
     #[test]
     fn list_multiple_mns() {
-        let temp_dir = TempDir::new().unwrap();
+        let temp_dir = TempDir::new().expect("test");
         let temp_dir_path = format!("{}", temp_dir.path().display());
 
-        temp_dir.child("mn0.md").touch().unwrap();
-        temp_dir.child("mn1.md").touch().unwrap();
-        temp_dir.child("mn2.md").touch().unwrap();
+        temp_dir.child("mn0.md").touch().expect("test");
+        temp_dir.child("mn1.md").touch().expect("test");
+        temp_dir.child("mn2.md").touch().expect("test");
 
         let state = State::from_test_state(
             TestStateBuilder::new()
                 .directory(temp_dir_path)
                 .build()
-                .unwrap(),
+                .expect("test"),
         )
-        .and_from_filesystem();
+        .and_from_filesystem()
+        .expect("test");
         match list(state) {
             Err(_) => assert!(false, "No other errors"),
-            Ok(None) => assert!(false),
-            Ok(Some(msg)) => assert_eq!(
+            Ok(msg) => assert_eq!(
                 msg,
                 format!(
                     "Your 3 available mnemonics are:\n  - {}\n  - {}\n  - {}\n",

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,30 +10,32 @@ mod utils;
 
 use add::add;
 use edit::edit;
+use err::CliErr;
 use list::list;
 use rm::rm;
 use show::show;
 use state::State;
 
 fn main() {
+    match run() {
+        Ok(std_out) => print!("{}", std_out),
+        Err(cli_err) => cli_err.handle_err(),
+    };
+}
+
+fn run() -> Result<String, CliErr> {
     let cli_args = cli::build_cli().get_matches();
 
-    let state = State::from_config_file()
-        .unwrap()
+    let state = State::from_config_file()?
         .and_from_clap_args(cli_args.clone())
-        .and_from_filesystem();
+        .and_from_filesystem()?;
 
-    let result = match cli_args.subcommand_name() {
+    match cli_args.subcommand_name() {
         Some("rm") => rm(state),
         Some("add") => add(state),
         Some("list") => list(state),
         Some("edit") => edit(state),
         Some("show") => show(state),
         _ => show(state),
-    };
-    match result {
-        Ok(None) => (),
-        Ok(Some(msg)) => println!("{}", msg),
-        Err(cli_err) => cli_err.handle_err(),
     }
 }

--- a/src/rm.rs
+++ b/src/rm.rs
@@ -4,7 +4,7 @@ use crate::utils;
 use colored::*;
 use std::{fs, io};
 
-pub fn rm(state: State) -> Result<Option<String>, CliErr> {
+pub fn rm(state: State) -> Result<String, CliErr> {
     let file_name_arguments = state.mnemonics();
     let dir_path = state.directory();
     let mut output_msg = String::new();
@@ -14,9 +14,9 @@ pub fn rm(state: State) -> Result<Option<String>, CliErr> {
             return Err(CliErr::MnemonicNotFound(file_name.to_string()));
         }
         if *state.rm().force() {
-            let file_deleted_msg = delete_file(full_path, &file_name)?;
+            delete_file(full_path, &file_name)?;
             // the list of mn_files in fs_state isn't mutable from here and thus isn't updated
-            output_msg.push_str(format!("{}\n", file_deleted_msg.unwrap()).as_str());
+            output_msg.push_str(format!("{} has been deleted.", &file_name.blue()).as_str());
         } else {
             println!(
                 "Are you sure you want to delete {}? [y/n]",
@@ -24,36 +24,33 @@ pub fn rm(state: State) -> Result<Option<String>, CliErr> {
             );
             let mut answer = String::new();
             // NOTE: state
-            io::stdin()
-                .read_line(&mut answer)
-                .expect("Should be able to read input from stdin");
+            io::stdin().read_line(&mut answer)?;
             loop {
                 match &answer[..] {
                     "y\n" | "yes\n" => {
-                        let file_deleted_msg = delete_file(full_path, &file_name)?;
-                        output_msg.push_str(format!("{}\n", file_deleted_msg.unwrap()).as_str());
+                        delete_file(full_path, &file_name)?;
+                        output_msg
+                            .push_str(format!("{} has been deleted.", &file_name.blue()).as_str());
                         break;
                     }
                     "n\n" | "no\n" => break,
                     _ => {
                         println!("Please type 'yes' ('y') or 'no' ('n')");
                         answer = String::new();
-                        io::stdin()
-                            .read_line(&mut answer)
-                            .expect("Should be able to read input from stdin");
+                        io::stdin().read_line(&mut answer)?;
                     }
                 }
             }
         }
     }
-    Ok(Some(output_msg))
+    Ok(output_msg)
 }
 
-fn delete_file(full_path: String, file_name: &str) -> Result<Option<String>, CliErr> {
+fn delete_file(full_path: String, file_name: &str) -> Result<(), CliErr> {
     // NOTE: state
     match fs::remove_file(full_path) {
         Err(e) => Err(CliErr::ErrDeletingMnemonic(file_name.to_string(), e)),
-        _ => Ok(Some(format!("{} has been deleted.", file_name.blue()))),
+        _ => Ok(()),
     }
 }
 
@@ -70,7 +67,7 @@ mod tests {
             TestStateBuilder::new()
                 .mnemonics(vec!["mn0".to_string()])
                 .build()
-                .unwrap(),
+                .expect("test"),
         );
 
         match rm(state) {
@@ -82,35 +79,34 @@ mod tests {
 
     #[test]
     fn delete_a_file() {
-        let temp_dir = TempDir::new().unwrap();
+        let temp_dir = TempDir::new().expect("test");
         let temp_dir_path = format!("{}", temp_dir.path().display());
-        temp_dir.child("mn0.md").touch().unwrap();
+        temp_dir.child("mn0.md").touch().expect("test");
         let full_path = format!("{}/mn0.md", temp_dir_path);
 
         match delete_file(full_path, "mn0") {
-            Ok(None) => assert!(false, "should print a msg"),
             Err(e) => assert!(false, format!("Should not have error: {:#?}", e)),
-            Ok(Some(_)) => assert!(true, "should return Some(msg)"),
+            Ok(()) => assert!(true, "should return Ok"),
         }
     }
     #[test]
     fn rm_force_flag() {
-        let temp_dir = TempDir::new().unwrap();
+        let temp_dir = TempDir::new().expect("test");
         let temp_dir_path = format!("{}", temp_dir.path().display());
-        temp_dir.child("mn0.md").touch().unwrap();
+        temp_dir.child("mn0.md").touch().expect("test");
 
         let state = State::from_test_state(
             TestStateBuilder::new()
                 .directory(temp_dir_path)
-                .rm(RmBuilder::new().force(true).build().unwrap())
+                .rm(RmBuilder::new().force(true).build().expect("test"))
                 .build()
-                .unwrap(),
+                .expect("test"),
         )
-        .and_from_filesystem();
+        .and_from_filesystem()
+        .expect("test");
         match rm(state) {
-            Ok(None) => assert!(false, "should print a msg"),
             Err(e) => assert!(false, format!("Should not have error: {:#?}", e)),
-            Ok(Some(_)) => assert!(true, "should return Some(msg)"),
+            Ok(msg) => assert!(true, "should return Ok with a msg: {}", msg),
         }
     }
 }


### PR DESCRIPTION
This PR closes #21, though it doesn't actually use `failure`.  After a bit more research, it turns out that `failure` is aimed at solving a different problem—it helps pass errors between libraries, but doesn't do a whole lot to reduce the verbosity of the error messages themselves.

This PR significantly expands error handling and, in fact, eliminates all `unwrap()` and `expect()` calls in non-test code.  Now, every error is handled and returned to the user with a (hopefully) useful error message; it should not be possible for `mn` to panic in user-facing code.